### PR TITLE
Removes the unsused Scene field from the SceneObject.

### DIFF
--- a/TowerOffense.Objects/Base/SceneObject.cs
+++ b/TowerOffense.Objects/Base/SceneObject.cs
@@ -1,16 +1,11 @@
 using Microsoft.Xna.Framework;
-using TowerOffense.Scenes;
 
 namespace TowerOffense.Objects.Base {
     public abstract class SceneObject {
 
         public bool IsDestroyed { get; private set; }
 
-        protected Scene Scene;
-
-        public SceneObject(Scene scene) {
-            Scene = scene;
-        }
+        public SceneObject() {}
 
         public virtual void Destroy() {
             IsDestroyed = true;

--- a/TowerOffense.Objects/Base/SceneWindow.cs
+++ b/TowerOffense.Objects/Base/SceneWindow.cs
@@ -3,7 +3,6 @@ using System.Windows.Forms;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
-using TowerOffense.Scenes;
 using ButtonState = Microsoft.Xna.Framework.Input.ButtonState;
 
 namespace TowerOffense.Objects.Base {
@@ -76,7 +75,7 @@ namespace TowerOffense.Objects.Base {
 
         private SwapChainRenderTarget _renderTarget;
 
-        public SceneWindow(Scene scene, Point position, Point size, int titleBarHeight = 24, int borderThickness = 1) : base(scene) {
+        public SceneWindow(Point position, Point size, int titleBarHeight = 24, int borderThickness = 1) : base() {
 
             var game = TOGame.Instance;
             _window = GameWindow.Create(game, 0, 0);

--- a/TowerOffense.Objects/HPDisplay.cs
+++ b/TowerOffense.Objects/HPDisplay.cs
@@ -1,6 +1,5 @@
 using Microsoft.Xna.Framework;
 using TowerOffense.Objects.Base;
-using TowerOffense.Scenes;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace TowerOffense.Objects {
@@ -8,7 +7,7 @@ namespace TowerOffense.Objects {
         private SpriteFont _font;
         private string _text;
 
-        public HpDisplay(Scene scene, Point position, Point size) : base(scene, position, size) {
+        public HpDisplay(Point position, Point size) : base(position, size) {
             _font = TOGame.Instance.Content.Load<SpriteFont>("Fonts/HpDisplay");
         }
 

--- a/TowerOffense.Scenes/Example/ExampleScene.cs
+++ b/TowerOffense.Scenes/Example/ExampleScene.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Windows.Forms;
 using Microsoft.Xna.Framework;
 using TowerOffense.Scenes.Example.Objects;
 
@@ -8,7 +5,7 @@ namespace TowerOffense.Scenes.Example {
     public class ExampleScene : Scene {
         public ExampleScene() : base() {
 
-            var worm = new Worm(this, new Point(400, 400), new Point(120, 120), 10, 24, 1);
+            var worm = new Worm(new Point(400, 400), new Point(120, 120), 10, 24, 1);
 
             worm.Draggable = false;
             worm.Closeable = false;

--- a/TowerOffense.Scenes/Example/Objects/ExampleWindow.cs
+++ b/TowerOffense.Scenes/Example/Objects/ExampleWindow.cs
@@ -3,7 +3,7 @@ using TowerOffense.Objects.Base;
 
 namespace TowerOffense.Scenes.Example.Objects {
     public class ExampleWindow : SceneWindow {
-        public ExampleWindow(Scene scene, Point position, Point size) : base(scene, position, size) { }
+        public ExampleWindow(Point position, Point size) : base(position, size) { }
 
         public override void Update(GameTime gameTime) {
             base.Update(gameTime);

--- a/TowerOffense.Scenes/Example/Objects/Segment.cs
+++ b/TowerOffense.Scenes/Example/Objects/Segment.cs
@@ -6,7 +6,7 @@ namespace TowerOffense.Scenes.Example.Objects {
 
         private SceneWindow _sceneWindow;
 
-        public Segment(Scene scene, Point position, Point size, SceneWindow sceneWindow) : base(scene, position, size) {
+        public Segment(Point position, Point size, SceneWindow sceneWindow) : base(position, size) {
         }
 
         public override void Update(GameTime gameTime) {

--- a/TowerOffense.Scenes/Example/Objects/WindowDeleter.cs
+++ b/TowerOffense.Scenes/Example/Objects/WindowDeleter.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.Xna.Framework;
 using TowerOffense.Objects.Base;
 
@@ -9,7 +8,7 @@ namespace TowerOffense.Scenes.Example.Objects {
         private double _timeThreshold;
         private SceneWindow _window;
 
-        public WindowDeleter(Scene scene, SceneWindow window, double timeThreshold) : base(scene) {
+        public WindowDeleter(SceneWindow window, double timeThreshold) : base() {
             _timeThreshold = timeThreshold;
             _window = window;
         }

--- a/TowerOffense.Scenes/Example/Objects/Worm.cs
+++ b/TowerOffense.Scenes/Example/Objects/Worm.cs
@@ -14,12 +14,12 @@ namespace TowerOffense.Scenes.Example.Objects {
         private double _time;
         private Random _random;
 
-        public Worm(Scene scene, Point position, Point size, int numSegments, int titleBarHeight, int borderThickness) : base(scene, position, size, titleBarHeight, borderThickness) {
+        public Worm(Point position, Point size, int numSegments, int titleBarHeight, int borderThickness) : base(position, size, titleBarHeight, borderThickness) {
             _position = new Vector2(position.X, position.Y);
             _segments = new List<Segment>();
             _random = new Random();
             for (int i = 0; i < numSegments; i++) {
-                _segments.Add(new Segment(Scene, position, new Point(60 - 5 * i, 60 - 5 * i), this));
+                _segments.Add(new Segment(position, new Point(60 - 5 * i, 60 - 5 * i), this));
             }
         }
 

--- a/TowerOffense.Scenes/HPTestScene/HPTestScene.cs
+++ b/TowerOffense.Scenes/HPTestScene/HPTestScene.cs
@@ -7,8 +7,8 @@ namespace TowerOffense.Scenes.HpTest {
         private HpKiller hpKiller;
         private HpDisplay hpDisplay;
         public HpTestScene(){
-            hpKiller = new HpKiller(this);
-            hpDisplay = new HpDisplay(this,new Point(0,0),new Point(120,120));
+            hpKiller = new HpKiller();
+            hpDisplay = new HpDisplay(new Point(0,0),new Point(120,120));
             this.AddObject(hpKiller);
             this.AddObject(hpDisplay);
         }

--- a/TowerOffense.Scenes/HPTestScene/Objects/HPKiller.cs
+++ b/TowerOffense.Scenes/HPTestScene/Objects/HPKiller.cs
@@ -1,5 +1,4 @@
 using Microsoft.Xna.Framework;
-using TowerOffense;
 using TowerOffense.Objects.Base;
 
 namespace TowerOffense.Scenes.HpTest.Objects {
@@ -8,7 +7,7 @@ namespace TowerOffense.Scenes.HpTest.Objects {
         private double timeCount = 0;
         private double timeLimit = 1;
 
-        public HpKiller(Scene scene) : base(scene) { }
+        public HpKiller() : base() { }
 
         public override void Update(GameTime gameTime) {
             timeCount += gameTime.ElapsedGameTime.TotalSeconds;

--- a/TowerOffense.Scenes/Title/Objects/TitleWindow.cs
+++ b/TowerOffense.Scenes/Title/Objects/TitleWindow.cs
@@ -1,10 +1,6 @@
-using System;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input;
 using TowerOffense.Objects.Base;
 using TowerOffense.Objects.Common;
-using TowerOffense.Scenes;
 using TowerOffense.Scenes.Example;
 
 namespace TowerOffense.Scenes.Title.Objects {
@@ -12,7 +8,7 @@ namespace TowerOffense.Scenes.Title.Objects {
 
         private Button _playButton;
 
-        public TitleWindow(Scene scene, Point position, Point size) : base(scene, position, size) {
+        public TitleWindow(Point position, Point size) : base(position, size) {
 
             var playButtonSize = new Point(96, 64);
 

--- a/TowerOffense.Scenes/Title/TitleScene.cs
+++ b/TowerOffense.Scenes/Title/TitleScene.cs
@@ -7,7 +7,7 @@ namespace TowerOffense.Scenes.Title {
         private TitleWindow _titleWindow;
 
         public TitleScene() : base() {
-            _titleWindow = new TitleWindow(this, new Point(800, 600), new Point(480, 270));
+            _titleWindow = new TitleWindow(new Point(800, 600), new Point(480, 270));
             _titleWindow.ClearColor = Color.Blue;
             _titleWindow.Closed += (_, _) => TOGame.Instance.Exit();
         }


### PR DESCRIPTION
We never actually use the scene reference at all, and I can't imagine any object needing any info from scene.